### PR TITLE
Added logging via Logging-module in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ You can also list available lights and ID's:
 
     ./tradfri_hue_workaround.py <bridge_ip> -l
 
+If you want a bit more verbose output, or even debug messages, you can add the following argument:
+
+    ./tradfri_hue_workaround.py -v <other_args>    # Info messages
+    ./tradfri_hue_workaround.py -vv <other_args>   # Debug messages
+
+
 ## Authentication against Philips Hue Bridge
 
 The first time you run the script you need to press the button on the Philips Hue Bridge.

--- a/tradfri_hue_workaround.py
+++ b/tradfri_hue_workaround.py
@@ -1,6 +1,13 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
 from phue import Bridge
 from time import sleep, time
-import argparse
+
+# Default values
+poll_default = 0.2
+delay_default = 1.2
 
 class TradfriLight():
     def __init__(self, light, brightness_delay = 1.0):
@@ -13,10 +20,12 @@ class TradfriLight():
     def check_and_update(self):
         brightness = self._light.brightness
         if self._last_brightness != brightness:
+            logging.info(f'Brightness changed detected for light "{self._light.name}": {self._last_brightness} -> {brightness}')
             self._has_changed = True
             self._t0 = time()
 
         if self._has_changed and self._t0 + self._brightness_delay < time():
+            logging.info(f'Brightness for light "{self._light.name}" set to {brightness}')
             self._light.brightness = brightness
             self._has_changed = False
 
@@ -29,29 +38,47 @@ def main(bridge, args):
 
     while True:
         for light in tradfri_lights:
+            logging.debug(f'Checking light {light._light.name}')
             light.check_and_update()
         
+        logging.debug(f'Sleeping for {args.poll_time} seconds...')
         sleep(args.poll_time)
 
 def list_lights(b: Bridge):
+    logging.debug(f'Getting list of lights...')
     light_list = b.get_light_objects()
-    print('Available lights:')
-    for light in light_list:
-        print(f'{light.light_id}: {light.name}')
+    logging.debug(f'List of lights: {light_list}')
+    print(f'Available lights:')
+    if light_list is not None:
+        for light in light_list:
+            print(f'{light.light_id}: {light.name}')
+    else:
+        print(f'<no lights found>')
 
 if __name__ == '__main__':
-    poll_default = 0.2
-    delay_default = 1.2
+    #¤logging.basicConfig(level=logging.WARNING)
     parser = argparse.ArgumentParser(description='Workaround script for IKEA Trådfri brightness issue on Philips Hue Bridge. Simply run the script with bridge IP and Trådfrid light ID\'s as argument. Remember to push the bridge button before starting the script the first time')
     parser.add_argument('bridge_ip')
     parser.add_argument('light_ids', nargs='*', type=float)
     parser.add_argument('-t', '--poll_time', default=poll_default, type=float, help=f'Set how often the lights are checked for brightness change. Value in seconds ({poll_default})')
     parser.add_argument('-d', '--brightness_delay',type = float, help=f'How long to wait after brightness is attempted changed before actually updating the brightness. Value in seconds ({delay_default})', default=delay_default)
-    parser.add_argument('-l', '--list', action='store_true', required=False, default=False,help='List available lights')
+    parser.add_argument('-l', '--list', action='store_true', required=False, default=False,help=f'List available lights')
+    parser.add_argument('-v', '--verbose', action='count', help=f'Be more verbose. -vv will print debug messages', default=1)
     args = parser.parse_args()
 
+    # Set logging level based on -v's:
+    verbose_level = 40 - (10*args.verbose) if args.verbose > 0 else 0
+    print(f'Verbose level: {verbose_level}')
+    logging.basicConfig(level=verbose_level, format='%(asctime)s %(levelname)s %(module)s: %(message)s',
+                    datefmt='%Y-%m-%d %H:%M:%S')
+
+    logging.info(f'Arguments: {args}')
+
     b = Bridge(args.bridge_ip)
+    logging.debug(f'Trying to connect to the bridge...')
     b.connect()
+    logging.debug(f'Connected to the bridge')
+    logging.debug(f'Getting the API...')
     b.get_api()
 
     if args.list:

--- a/tradfri_hue_workaround.py
+++ b/tradfri_hue_workaround.py
@@ -68,17 +68,16 @@ if __name__ == '__main__':
 
     # Set logging level based on -v's:
     verbose_level = 40 - (10*args.verbose) if args.verbose > 0 else 0
-    print(f'Verbose level: {verbose_level}')
     logging.basicConfig(level=verbose_level, format='%(asctime)s %(levelname)s %(module)s: %(message)s',
                     datefmt='%Y-%m-%d %H:%M:%S')
 
     logging.info(f'Arguments: {args}')
 
     b = Bridge(args.bridge_ip)
-    logging.debug(f'Trying to connect to the bridge...')
+    logging.info(f'Trying to connect to the bridge...')
     b.connect()
-    logging.debug(f'Connected to the bridge')
-    logging.debug(f'Getting the API...')
+    logging.info(f'Connected to the bridge')
+    logging.info(f'Getting the API...')
     b.get_api()
 
     if args.list:

--- a/tradfri_hue_workaround.py
+++ b/tradfri_hue_workaround.py
@@ -77,9 +77,10 @@ if __name__ == '__main__':
     logging.info(f'Trying to connect to the bridge...')
     b.connect()
     logging.info(f'Connected to the bridge')
-    logging.info(f'Getting the API...')
+    logging.info(f'Fetching the API resource...')
     b.get_api()
-
+    logging.info(f'API resource acquired')
+    
     if args.list:
         list_lights(b)
     elif len(args.light_ids) > 0:


### PR DESCRIPTION
The script are now able to log (to STDOUT). Per default it will only log warning or more severe events (as before?), but now a user may turn on more logging by adding `-v` or `-vv` as an argument.

This will result in logging from both the script and the `phue`-module, so I have formatted the log-output in such a manner that you can distinguish between the two.

Example:
```
$ ./tradfri_hue_workaround.py -v 192.168.10.54 25 26 27 23 24
2025-03-09 12:30:59 INFO tradfri_hue_workaround: Arguments: Namespace(bridge_ip='192.168.10.54', light_ids=[25.0, 26.0, 27.0, 23.0, 24.0], poll_time=0.2, brightness_delay=1.2, list=False, verbose=2)
2025-03-09 12:30:59 INFO phue: Attempting to connect to the bridge...
2025-03-09 12:30:59 INFO phue: Using ip: 192.168.10.54
2025-03-09 12:30:59 INFO phue: Using username from config: <hidden>
2025-03-09 12:30:59 INFO tradfri_hue_workaround: Trying to connect to the bridge...
2025-03-09 12:30:59 INFO phue: Attempting to connect to the bridge...
2025-03-09 12:30:59 INFO phue: Using ip: 192.168.10.54
2025-03-09 12:30:59 INFO phue: Using username: <hidden>
2025-03-09 12:30:59 INFO tradfri_hue_workaround: Connected to the bridge
2025-03-09 12:30:59 INFO tradfri_hue_workaround: Fetching the API resource...
2025-03-09 12:30:59 INFO tradfri_hue_workaround: API resource acquired
2025-03-09 12:31:10 INFO tradfri_hue_workaround: Brightness changed detected for light "Ikea lys kontor 1": 143 -> 204
2025-03-09 12:31:10 INFO tradfri_hue_workaround: Brightness changed detected for light "Ikea kontor 2": 143 -> 204
2025-03-09 12:31:12 INFO tradfri_hue_workaround: Brightness for light "Ikea lys kontor 1" set to 204
2025-03-09 12:31:12 INFO tradfri_hue_workaround: Brightness for light "Ikea kontor 2" set to 204
2025-03-09 12:31:31 INFO tradfri_hue_workaround: Brightness changed detected for light "IKEA Lys gang 1": 143 -> 25
2025-03-09 12:31:31 INFO tradfri_hue_workaround: Brightness changed detected for light "IKEA Lys gang 2": 143 -> 25
2025-03-09 12:31:31 INFO tradfri_hue_workaround: Brightness changed detected for light "IKEA Lys gang 3": 143 -> 25
2025-03-09 12:31:33 INFO tradfri_hue_workaround: Brightness for light "IKEA Lys gang 3" set to 25
2025-03-09 12:31:33 INFO tradfri_hue_workaround: Brightness for light "IKEA Lys gang 1" set to 25
2025-03-09 12:31:33 INFO tradfri_hue_workaround: Brightness for light "IKEA Lys gang 2" set to 25
```